### PR TITLE
fix: add missing npm scripts and fix deprecated Image prop

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -32,10 +32,9 @@ export function Header() {
               <Image
                 src="/logo_maelstrom.svg"
                 alt="Maelstrom Logo"
-                className="dark:invert"
-                width={"50"}
-                height={"50"}
-                objectFit="contain"
+                className="dark:invert object-contain"
+                width={50}
+                height={50}
               />
             </div>
             <span className="text-xl font-bold gradient-text">Maelstrom</span>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@icons-pack/react-simple-icons": "^13.7.0",


### PR DESCRIPTION
## Summary
This PR fixes two issues:

### 1. Missing npm scripts
The README.md mentions running these scripts for contribution:
- `npm run lint:fix`
- `npm run typecheck`

But they were missing from package.json. This PR adds them.

### 2. Deprecated Next.js Image prop
The `objectFit` prop was deprecated in Next.js 13+ and shows console warnings:
> Image with src "/logo_maelstrom.svg" has legacy prop "objectFit"

Fixed by using `className="object-contain"` instead (Tailwind class).
Also changed `width`/`height` from strings to numbers for proper typing.

## Testing
-  `npm run build` passes
-  `npm run typecheck` passes  
-  `npm run lint` works correctly
-   No console warnings about deprecated props

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined header component image properties and styling approach.

* **Chores**
  * Added new development scripts for automated linting fixes and TypeScript type checking.
  * Updated existing lint script for broader coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->