### PR TITLE
fix: update footer aria-labels to Maelstrom branding

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -26,25 +26,25 @@ export function Footer({
       platform: "GitHub",
       url: "https://github.com/StabilityNexus",
       icon: <SiGithub className="h-5 w-5" />,
-      ariaLabel: "Visit HammerChain on GitHub"
+      ariaLabel: "Visit Maelstrom on GitHub"
     },
     {
       platform: "Discord",
       url: "https://discord.gg/BNsAtaX5",
       icon: <SiDiscord className="h-5 w-5" />,
-      ariaLabel: "Join HammerChain Discord community"
+      ariaLabel: "Join Maelstrom Discord community"
     },
     {
       platform: "Telegram",
       url: "https://t.me/StabilityNexus",
       icon: <SiTelegram className="h-5 w-5" />,
-      ariaLabel: "Follow HammerChain on Telegram"
+      ariaLabel: "Follow Maelstrom on Telegram"
     },
     {
       platform: "Twitter",
       url: "https://x.com/StabilityNexus",
       icon: <SiX className="h-5 w-5" />,
-      ariaLabel: "Follow HammerChain on Twitter"
+      ariaLabel: "Follow Maelstrom on Twitter"
     }
   ];
 


### PR DESCRIPTION
### Summary
Updated Footer `aria-label` text to reference **Maelstrom** instead of the previous "HammerChain."

### Why
Ensures accessibility labels match the current project branding and improves screen-reader accuracy.

### Changes
- Updated aria-label strings only
- No UI or logic changes

Fixes #16


### Solution
```
  const defaultSocialLinks: SocialLink[] = [
    {
      platform: "GitHub",
      url: "https://github.com/StabilityNexus",
      icon: <SiGithub className="h-5 w-5" />,
      ariaLabel: "Visit Maelstrom on GitHub"
    },
    {
      platform: "Discord",
      url: "https://discord.gg/BNsAtaX5",
      icon: <SiDiscord className="h-5 w-5" />,
      ariaLabel: "Join Maelstrom Discord community"
    },
    {
      platform: "Telegram",
      url: "https://t.me/StabilityNexus",
      icon: <SiTelegram className="h-5 w-5" />,
      ariaLabel: "Follow Maelstrom on Telegram"
    },
    {
      platform: "Twitter",
      url: "https://x.com/StabilityNexus",
      icon: <SiX className="h-5 w-5" />,
      ariaLabel: "Follow Maelstrom on Twitter"
    }
  ];
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated accessibility labels in footer social links to reflect brand name updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->