### PR TITLE
stop image dragging -user-drag: none;

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -146,6 +146,18 @@
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 
+  img {
+    -webkit-user-drag: none;
+    -khtml-user-drag: none;
+    -moz-user-drag: none;
+    -o-user-drag: none;
+    user-drag: none;
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+  }
+
   /* Custom scrollbar */
   ::-webkit-scrollbar {
     width: 8px;


### PR DESCRIPTION
### Summary

Prevents images from being draggable across the application to avoid unwanted drag previews and improve interaction smoothness.

Closes #19 
### Solution

Disable image dragging globally using a base CSS rule.

**Changes**

**Modified file:**
```
app/globals.css
```

**Added:**
```
img {
    -webkit-user-drag: none;
    -khtml-user-drag: none;
    -moz-user-drag: none;
    -o-user-drag: none;
    user-drag: none;
    user-select: none;
    -webkit-user-select: none;
    -moz-user-select: none;
    -ms-user-select: none;
  }

```

### Impact

- Improves UX consistency
- No behavior or visual regressions
- Applies safely across all components

### Checklist

- [x] No breaking changes
- [x]  Scoped to global base styles
- [x]  Improves UI polish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Disabled image dragging and text selection across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->