### PR TITLE
Fixed UX confusion when no token selected on swap page

### DIFF
--- a/components/swap/token-selector.tsx
+++ b/components/swap/token-selector.tsx
@@ -55,7 +55,7 @@ export function TokenSelector({
               {selectedTokenData?.symbol.toUpperCase().charAt(0)}
             </span>
           </div>
-          <span>{selectedTokenData?.symbol.toUpperCase()}</span>
+          <span>{selectedTokenData?.symbol.toUpperCase() || "Select"}</span>
           <ChevronDown className="h-4 w-4 text-muted-foreground" />
         </div>
       </Button>


### PR DESCRIPTION
This pull request makes a small user interface improvement to the token selector component. Now, if no token is selected, the selector will display "Select" instead of leaving the field blank.

* Display "Select" as a fallback in the token selector if no token is chosen (`components/swap/token-selector.tsx`).


Before 
<img width="1436" height="1342" alt="image" src="https://github.com/user-attachments/assets/bc96d676-57cc-41ad-930d-3cc1eea332f6" />


After
<img width="619" height="626" alt="image" src="https://github.com/user-attachments/assets/a13201ba-32cd-4bf0-9f7b-a35cdabf14cf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token selector display to show "Select" placeholder text when no token is selected, providing clearer visual feedback about the current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->