### PR TITLE
fix(swap): preserve and recalculate amounts when swapping tokens

### DIFF
--- a/components/swap/swap-interface.tsx
+++ b/components/swap/swap-interface.tsx
@@ -68,6 +68,8 @@ export function SwapInterface() {
   const [validationError, setValidationError] = useState<string>("");
   const [zeroSlippageMode, setZeroSlippageMode] = useState<boolean>(true); // Default to zero slippage mode
   const swapJustHappenedRef = useRef(false);
+  const tokenInSellPriceForRef = useRef<Token | null>(null);
+  const tokenOutBuyPriceForRef = useRef<Token | null>(null);
 
   const calculateOutput = (amount: string, isInput: boolean) => {
     setValidationError("");
@@ -184,6 +186,7 @@ export function SwapInterface() {
       const newExchangeRate = tokenOutBuyPrice / newSellPrice;
 
       setTokenInSellPrice(newSellPrice);
+      tokenInSellPriceForRef.current = token;
       setEthInReserve(reserve?.ethReserve);
 
       setSwapState((prev) => {
@@ -223,6 +226,7 @@ export function SwapInterface() {
       const newExchangeRate = newBuyPrice / tokenInSellPrice;
       setTokenOutReserve(reserve?.tokenReserve);
       setTokenOutBuyPrice(newBuyPrice);
+      tokenOutBuyPriceForRef.current = token;
 
       setSwapState((prev) => {
         const formattedExchangeRate =
@@ -273,10 +277,13 @@ export function SwapInterface() {
     }
   };
 
-  // After swap, recalc the other amount once new prices are available
+  // After swap, recalc the other amount only when both prices match the current token pair
   useEffect(() => {
     if (!swapJustHappenedRef.current) return;
     if (!swapState.tokenIn || !swapState.tokenOut || !tokenInSellPrice || !tokenOutBuyPrice) return;
+    const sellPriceForCurrentIn = tokenInSellPriceForRef.current?.address === swapState.tokenIn?.address;
+    const buyPriceForCurrentOut = tokenOutBuyPriceForRef.current?.address === swapState.tokenOut?.address;
+    if (!sellPriceForCurrentIn || !buyPriceForCurrentOut) return;
     swapJustHappenedRef.current = false;
     if (swapState.amountIn) {
       setSwapState((prev) => ({ ...prev, amountOut: calculateOutput(prev.amountIn, true) }));


### PR DESCRIPTION
Closes #38 
### 📄 Summary

This PR fixes an issue in the swap interface where clicking the **swap tokens (↑↓)** button cleared the entered amounts instead of preserving and recalculating them for the new token direction.

The updated behavior now matches standard swap UX expectations.

---

### Problem

Previously, `handleSwapTokens` explicitly reset both `amountIn` and `amountOut` to empty strings when swapping tokens.
As a result:

* User-entered values were lost
* Users had to re-enter amounts manually
* Swap flow felt broken and unintuitive

---

### Solution

* Preserve `amountIn` and `amountOut` when swapping tokens
* Swap `tokenIn` and `tokenOut` first
* Re-fetch prices for the new direction
* Recalculate the corresponding amount **after** updated prices are available
* Use a `useRef` flag to avoid unnecessary re-renders or race conditions

This ensures amounts are recalculated correctly without clearing user input.

---

### Behavior After Fix

1. User enters an amount
2. Clicks swap (↑↓)
3. Tokens are swapped
4. Existing amount is preserved
5. Output is recalculated based on the new direction

---

### Files Changed

* `components/swap/swap-interface.tsx`

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Swap now preserves entered amounts when swapping token sides and automatically recalculates the counterpart amount once current market prices load, preventing unintended clearing and ensuring accurate post-swap values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->