### PR TITLE
(fix)/pool-cta-ui-navigation

### DIFF
--- a/components/dashboard/pools-table.tsx
+++ b/components/dashboard/pools-table.tsx
@@ -1,4 +1,6 @@
 "use client";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 import { TokenRow } from "../tokens/TokenRow";
 import { TokenRowSkeleton } from "../tokens/TokenRowSkeleton";
 import { RowPool } from "@/types/pool";
@@ -39,9 +41,9 @@ export function PoolsTable(
             before:absolute before:inset-0 before:bg-background-800/30 before:-z-10"
           >
             <p className="text-muted-foreground/70">No active pools found</p>
-            <button className="mt-4 text-sm text-accent hover:text-accent-foreground transition-colors">
-              Explore Available Pools
-            </button>
+            <Button asChild className="mt-4">
+              <Link href="/pools">Explore Available Pools</Link>
+            </Button>
           </div>
         )}
       </div>


### PR DESCRIPTION
Closes #33 
## 🧩 Description

### Problem

On the Dashboard empty state, the **“Explore Available Pools”** element appeared clickable but:

* Did not clearly look like a primary call-to-action
* Was easy to miss due to text-only styling
* Reduced discoverability for new users with no active pools

### Solution

This PR improves the empty state CTA by:

* Converting **“Explore Available Pools”** into a **proper CTA-style button**
* Aligning the styling with existing design system components
* Preserving layout and copy while improving visual hierarchy
* Guiding new users clearly toward the next step (`/pools`)

### Why this matters

* Improves onboarding UX for first-time users
* Makes the next action obvious when no pools exist
* Aligns dashboard behavior with standard product UX patterns

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved button styling and navigation behavior in the pools dashboard empty state for better user experience when no active pools are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->