### PR TITLE
 [chainId] --> [chainId, writeContractAsync, publicClient] fixed useMemo to avoid older reference

### DIFF
--- a/components/swap/swap-interface.tsx
+++ b/components/swap/swap-interface.tsx
@@ -38,7 +38,7 @@ export function SwapInterface() {
   const publicClient = usePublicClient();
   const contractClient = useMemo(
     () => new ContractClient(writeContractAsync, publicClient, chainId),
-    [chainId]
+    [chainId, writeContractAsync, publicClient]
   );
   const { chain } = useAccount();
   const baseUrl = chain?.blockExplorers?.default.url;


### PR DESCRIPTION
Fixed issue #57
Closes #57

@kaneki003 Please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed swap interface to properly update when network configuration or contract state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->