### PR TITLE
feat: add automated merge conflict labeling workflow

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,0 +1,26 @@
+name: PR Maintenance
+on:
+  # Check when a PR is updated
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  # Crucial: Re-check all PRs when Next.js code is merged to main
+  push:
+    branches: [main]
+
+jobs:
+  conflict-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Update Conflict Labels
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "status: conflicted"
+          removeOnClean: true
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          # A friendly nudge for the contributor
+          commentOnDirty: |
+            Hello! This PR now has conflicts with the main branch. 
+            Please rebase or merge main into your branch to keep the review process moving! 🚀


### PR DESCRIPTION
This PR introduces a GitHub Action to automate the management of a needs-rebase label, ensuring that the status of a PR is visible at a glance.

Summary of Changes
Added Conflict Detection Workflow: A new GitHub Action (.github/workflows/check-conflicts.yml) that triggers on PR synchronization and updates to the main branch.

Automated Labeling: * Adds a needs-rebase label if the PR has merge conflicts.

Automatically removes the label once the contributor resolves the conflicts.

Maintainer Visibility: Enables filtering the PR list by "No Label" to prioritize merge-ready work.
<img width="903" height="504" alt="Screenshot 2026-02-09 at 11 58 39 PM" src="https://github.com/user-attachments/assets/9eada937-9115-42a3-96ab-b60315a8a7f8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated pull request conflict detection that labels conflicted pull requests and sends notifications to contributors about resolving conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->